### PR TITLE
фикс дублирования сообщений scp-263

### DIFF
--- a/code/modules/SCP/SCPs/SCP-263.dm
+++ b/code/modules/SCP/SCPs/SCP-263.dm
@@ -224,6 +224,9 @@
 /obj/scp263/attack_hand(mob/living/carbon/human/M)
 	if(!istype(M) || M.a_intent != I_HELP || !is_alive())
 		return ..()
+	if(state == STATE_IDLE)
+		to_chat(M, SPAN_WARNING("Have you already turned on old telivision."))
+		return
 	state = STATE_IDLE
 	update_icon()
 


### PR DESCRIPTION
# Основные изменения
Добавил проверку включенности телевизора.   Если он включен - игрок более не сможет включить его.

### До:
<img width="254" height="127" alt="image" src="https://github.com/user-attachments/assets/837e8b1d-ba24-45a6-b7ef-7f82c4fd3b6c" />

### После:

<img width="263" height="70" alt="image" src="https://github.com/user-attachments/assets/cc98d10c-3dd2-4a98-93b6-9eb5c9aeecdb" />
<img width="351" height="29" alt="image" src="https://github.com/user-attachments/assets/291a4697-ee2e-4a0a-9919-2174d54bc590" />

