### PR TITLE
Floating chat (runechat) for emotes

### DIFF
--- a/code/modules/emotes/emote_define.dm
+++ b/code/modules/emotes/emote_define.dm
@@ -90,6 +90,10 @@
 
 	if(ismob(user))
 		var/mob/M = user
+
+		// Floating chat
+		INVOKE_ASYNC(M, TYPE_PROC_REF(/atom/movable, animate_emote), use_3p, 0)
+
 		if(message_type == AUDIBLE_MESSAGE)
 			if(isliving(user))
 				var/mob/living/L = user

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -122,17 +122,23 @@
 		return
 
 	var/input
+	var/emote_text
 	if(!message)
 		input = sanitize(input(src,"Choose an emote to display.") as text|null)
 	else
 		input = message
 
 	if(input)
+		emote_text = message // Copy for floating chat
 		message = format_emote(src, message)
 	else
 		return
 	message = process_chat_markup(message)
-	if (message)
+
+	// Floating chat
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, animate_emote), emote_text, 1)
+
+	if(message)
 		log_emote("[name]/[key] : [message]")
 	//do not show NPC animal emotes to ghosts, it turns into hellscape
 	var/check_ghosts = client ? /datum/client_preference/ghost_sight : null

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -66,6 +66,61 @@ var/global/list/floating_chat_colors = list()
 			else
 				C.images += gibberish
 
+
+// Some cursed things for emotes
+/atom/movable/proc/animate_emote(message, tack_period = 0, duration = CHAT_MESSAGE_LIFESPAN)
+	set waitfor = FALSE
+
+	var/mob/M = src
+	var/emote_view = world.view
+	var/turf/T = get_turf(M)
+	var/list/listening = list()
+	var/list/listening_obj = list()
+
+	if(T)
+		get_mobs_and_objs_in_view_fast(T, emote_view, listening, listening_obj, /datum/client_preference/ghost_ears)
+	else
+		return
+
+	var/list/emote_recipients = list()
+	for(var/mob/E in listening)
+		if(E && E.client)
+			emote_recipients += E.client
+
+	if (tack_period) // To format the emote, if it's custom, add a period.
+		message = "#[message]."
+	else
+		message = "#[message]"
+
+	/// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
+	var/static/regex/url_scheme = new(@"[A-Za-z][A-Za-z0-9+-\.]*:\/\/", "g")
+	message = replacetext(message, url_scheme, "")
+
+	var/static/regex/html_metachars = new(@"&[A-Za-z]{1,7};", "g")
+	message = replacetext(message, html_metachars, "")
+
+	//additional style params for the message
+	var/style
+	var/fontsize = 6
+	var/limit = 120
+
+	if(length(message) > limit)
+		message = "[copytext(message, 1, limit)]..."
+
+	if(!global.floating_chat_colors[name])
+		global.floating_chat_colors[name] = get_random_colour(0, 160, 230)
+	style += "color: [global.floating_chat_colors[name]];"
+
+	var/image/emote_text = generate_floating_text(src, capitalize(message), style, fontsize, duration, emote_recipients)
+	var/image/move_trim = generate_floating_text(src, capitalize(message), style, fontsize, duration, emote_recipients)
+	if(move_trim) // It is necessary in order to move the message up
+		move_trim = 0
+
+	for(var/client/C in emote_recipients)
+		if(C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
+			C.images += emote_text
+
+
 /proc/generate_floating_text(atom/movable/holder, message, style, size, duration, show_to)
 	var/image/I = image(null, get_atom_on_turf(holder))
 	I.layer=FLY_LAYER


### PR DESCRIPTION
Well, it's working

## About the Pull Request

 Added floating chat support for emotes. They will now appear on your head in the "#message" format.

## Why It's Good For The Game

You can see emotes right away.

## Changelog

add: Added floating chat support for emotes.

<img width="480" height="480" alt="scrnshot1" src="https://github.com/user-attachments/assets/8e8b033b-92ce-40d2-bb1f-8b188ceb69fd" />
<img width="480" height="480" alt="scrnshot2" src="https://github.com/user-attachments/assets/7e2868fd-16bc-4bec-b488-2573336a4530" />
